### PR TITLE
Fixes for failing test cases

### DIFF
--- a/blockstack_proofs/htmlparsing.py
+++ b/blockstack_proofs/htmlparsing.py
@@ -11,28 +11,27 @@
 from bs4 import BeautifulSoup
 from .sites import SITES
 
-GITHUB_CONTENT_TAG = 'blob instapaper_body'
-GITHUB_DESCRIPTION_TAG = 'repository-description'
-GITHUB_FILE_TAG = 'blob-wrapper data type-text'
-
+GITHUB_CONTENT_TAG = 'blob-wrapper'
+GITHUB_DESCRIPTION_TAG = 'repository-meta-content'
+GITHUB_FILE_TAG = 'user-select-contain gist-blob-name css-truncate-target'
 
 def get_github_text(raw_html):
 
     html = BeautifulSoup(raw_html, "html.parser")
 
-    gist_description = html.body.find('div', attrs={'class': GITHUB_CONTENT_TAG})
+    gist_description = html.find('div', {'class': GITHUB_CONTENT_TAG})
 
     if gist_description is not None:
         gist_description = gist_description.text
     else:
-        gist_description = html.body.find('div', attrs={'class': GITHUB_DESCRIPTION_TAG})
+        gist_description = html.find('div', {'class': GITHUB_DESCRIPTION_TAG})
 
         if gist_description is not None:
             gist_description = gist_description.text
         else:
             gist_description = ''
 
-    file_text = html.body.find('div', attrs={'class': GITHUB_FILE_TAG})
+    file_text = html.find('div', {'class': GITHUB_FILE_TAG})
 
     if file_text is not None:
         file_text = file_text.text

--- a/blockstack_proofs/proofs.py
+++ b/blockstack_proofs/proofs.py
@@ -45,7 +45,6 @@ def contains_valid_proof_statement(search_text, username):
 
 
 def is_valid_proof(site, site_username, username, proof_url):
-
     site_username = site_username.lower()
     proof_url = proof_url.lower()
     username = username.lower()
@@ -58,8 +57,9 @@ def is_valid_proof(site, site_username, username, proof_url):
     if not proof_url.startswith(check_url):
 
         if site == 'facebook':
-            check_url = SITES['facebook-www']['base_url'] + site_username
-            if not proof_url.startswith(check_url):
+            check_url_dot = SITES['facebook-www']['base_url'] + site_username;
+            check_url = SITES['facebook-www']['base_url'] + site_username.strip(['.']);
+            if not proof_url.startswith(check_url_dot) and proof_url.startsWith(check_url):
                 return False
         else:
             return False


### PR DESCRIPTION
GitHub proofs were failing because the CSS classes had changed. In addition, BeautifulSoup's html.body.find() was not working as expected (changed to html.find())

A Facebook proof was failing because the test was looking for the Username in the URL. The username had a dot that was being redirect by Facebook to the dotless version. Updated the check to allow dotted or dotless username in the Facebook url.