### PR TITLE
Add support for address-based proofs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='blockstack-proofs',
-    version='0.0.8',
+    version='0.0.9',
     url='https://github.com/blockstack/blockstack-proofs',
     license='MIT',
     author='Blockstack.org',


### PR DESCRIPTION
This PR adds support for address-based proofs to Blockstack proofs in Python.

I know the original plan was to have the Python resolver code (e.g., core.blockstack.org) try to use the proof checking code from `blockstack.js`, but that would require one of:

a. a shell out, which I implemented, but am somewhat uncomfortable with its security implications 
b. a inter-process procedure call

Updating the Python proofs library is simpler for now than either of those options. If we want to deprecate the Python proofs library, we can eventually also spin out the resolver code (it's a fairly limited piece of code) into a node server.